### PR TITLE
Add backend env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ backend/coverage/
 backend/*.sqlite
 backend/*.db
 backend/.env*
+!backend/.env.example
 backend/test-results/
 
 ############################################################

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+MONGO_URI=mongodb://localhost:27017/chatdb
+RABBITMQ_URL=amqp://user:password@localhost:5672
+RABBITMQ_QUEUE=chat_queue


### PR DESCRIPTION
## Summary
- add example environment variables for the backend
- tweak .gitignore to include `backend/.env.example`

## Testing
- `npm run build` *(fails: cannot find modules)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855c8bacac4832ebb965c3dc324ec68